### PR TITLE
Small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ class Product extends AggregateRoot
     }
 }
 
-class ProductWasCreated implement DomainEvent
+class ProductWasCreated implements DomainEvent
 {
     private $name;
 


### PR DESCRIPTION
The keyword to implement an interface to a class in php in `implements` instead of `implement`