### PR TITLE
Fix #4 - Mutating to another state inside a mutation do not keep the order of events

### DIFF
--- a/src/DomainEvent/AggregateRoot.php
+++ b/src/DomainEvent/AggregateRoot.php
@@ -60,8 +60,8 @@ abstract class AggregateRoot
             throw AggregateRootException::missingMutationOnAggregate($this, $method);
         }
 
-        $this->$method($event);
         $this->mutations[] = $event;
+        $this->$method($event);
     }
 
     /**


### PR DESCRIPTION

* add event to stream before execution of mutation