### PR TITLE
Fix #9 - Cannot use the EventPublisher in a symfony application

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ $product = Product::create('lightsaber');
 $publisher->publishChanges($product->uncommitedEvents()); // will notify the listener and call the DoSomethingProductCreated::doSomething() method
 ```
 
+We currently support [third party](/docs/ports.md) adapters to allow you to plug-in the library into your infrastructure.
+
 ## Naming standard
 
 The events method on `AggregateRoot` children must be prefixed with `on` and followed by

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,12 @@
 
 # 2.0.0
 
-* Upgrade/php version bump
+* Upgrade/php version bump (**BC break**).
+* Add compiler pass to use in symfony application (**BC break**).
+
+**Note**: This release introduce the following **BC breaks**:
+
+* The namespace for classes in `Star\Component\DomainEvent\Symfony` was changed to `Star\Component\DomainEvent\Ports\Symfony`.
 
 # 1.0.1
 

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,12 @@
         "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "symfony/event-dispatcher": "^2.5",
         "phpstan/phpstan": "*",
         "phpstan/phpstan-phpunit": "*",
-        "squizlabs/php_codesniffer": "^3.4"
+        "phpunit/phpunit": "^7.0",
+        "squizlabs/php_codesniffer": "^3.4",
+        "symfony/dependency-injection": "^4.3",
+        "symfony/event-dispatcher": "^2.5"
     },
     "suggest": {
         "symfony/event-dispatcher": "Allows the usage of the SymfonyPublisher adapter provided by the star/domain-event."

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -1,0 +1,7 @@
+# Ports
+
+This package currently support the following third party libs or framework:
+
+* [Symfony framework](/src/Ports/Symfony/README.md)
+
+Note: Any new implementation is welcome. Go submit a PR. 

--- a/src/Ports/Symfony/DependencyInjection/EventPublisherPass.php
+++ b/src/Ports/Symfony/DependencyInjection/EventPublisherPass.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Star\Component\DomainEvent\Ports\Symfony\DependencyInjection;
+
+use Star\Component\DomainEvent\EventPublisher;
+use Star\Component\DomainEvent\Ports\Symfony\SymfonyPublisher;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class EventPublisherPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    private $event_dispatcher;
+
+    public function __construct(string $event_dispatcher = 'event_dispatcher')
+    {
+        $this->event_dispatcher = $event_dispatcher;
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $definition = new Definition(SymfonyPublisher::class, [new Reference($this->event_dispatcher)]);
+        foreach ($container->findTaggedServiceIds('star.event_listener') as $serviceId => $tags) {
+            $definition->addMethodCall('subscribe', [new Reference($serviceId)]);
+        }
+
+        $container->setDefinition('star.event_publisher_default', $definition);
+        $container->setAlias('star.event_publisher', 'star.event_publisher_default');
+        $container->setAlias(EventPublisher::class, 'star.event_publisher');
+    }
+}

--- a/src/Ports/Symfony/EventAdapter.php
+++ b/src/Ports/Symfony/EventAdapter.php
@@ -5,7 +5,7 @@
  * (c) Yannick Voyer <star.yvoyer@gmail.com> (http://github.com/yvoyer)
  */
 
-namespace Star\Component\DomainEvent\Symfony;
+namespace Star\Component\DomainEvent\Ports\Symfony;
 
 use Star\Component\DomainEvent\DomainEvent;
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Ports/Symfony/README.md
+++ b/src/Ports/Symfony/README.md
@@ -1,0 +1,13 @@
+# Symfony adapter
+
+See [Symfony documentation](https://symfony.com) for more information.
+
+## Compiler pass
+
+You can use the provided `EventPublisherPass` that will manage the registering of the event publisher.
+The compiler pass will register a service `star.event_publisher` with an alias `Star\Component\DomainEvent\EventPublisher`.
+A tag named `star.event_listener` is also used to mark your services as listeners.
+
+1. Register the [compiler pass](https://symfony.com/doc/current/service_container/compiler_passes.html) to your container.
+2. Register your service with the [tag](https://symfony.com/doc/current/service_container/tags.html) `star.event_listener`.
+3. You listener should now be invoked when a service calls the `EventPublisher::publish()` method.

--- a/src/Ports/Symfony/SymfonyPublisher.php
+++ b/src/Ports/Symfony/SymfonyPublisher.php
@@ -5,7 +5,7 @@
  * (c) Yannick Voyer <star.yvoyer@gmail.com> (http://github.com/yvoyer)
  */
 
-namespace Star\Component\DomainEvent\Symfony;
+namespace Star\Component\DomainEvent\Ports\Symfony;
 
 use Star\Component\DomainEvent\BadMethodCallException;
 use Star\Component\DomainEvent\DomainEvent;

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -11,12 +11,12 @@ use PHPUnit\Framework\TestCase;
 
 final class AggregateRootTest extends TestCase
 {
-    /**
-     * @expectedException        \Star\Component\DomainEvent\AggregateRootException
-     * @expectedExceptionMessage The mutation 'onMissingMethodEvent' do not exists on aggregate 'Star\Component\DomainEvent\StubAggregate'.
-     */
     public function test_it_should_throw_exception_when_method_is_missing(): void
     {
+        $this->expectException(AggregateRootException::class);
+        $this->expectExceptionMessage(
+            "The mutation 'onMissingMethodEvent' do not exists on aggregate 'Star\Component\DomainEvent\StubAggregate'."
+        );
         StubAggregate::fromStream([new MissingMethodEvent()]);
     }
 

--- a/tests/Ports/Symfony/DependencyInjection/EventPublisherPassTest.php
+++ b/tests/Ports/Symfony/DependencyInjection/EventPublisherPassTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Star\Component\DomainEvent\Ports\Symfony\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Star\Component\DomainEvent\EventListener;
+use Star\Component\DomainEvent\EventPublisher;
+use Star\Component\DomainEvent\Fixtures\Blog\Event\BlogWasCreated;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+final class EventPublisherPassTest extends TestCase
+{
+    public function test_it_should_pass_domain_event_to_listener_using_publisher_fqcn(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('event_dispatcher', EventDispatcher::class);
+        $builder->addCompilerPass(new EventPublisherPass());
+        $builder->register(SomeListener::class, SomeListener::class)->addTag('star.event_listener');
+        $builder->register(MyController::class, MyController::class)
+            ->addArgument(new Reference(EventPublisher::class))
+            ->setPublic(true);
+        $builder->compile();
+
+        /**
+         * @var MyController $service
+         */
+        $service = $builder->get(MyController::class);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('My blog works!!');
+        $service->doAction('My blog');
+    }
+
+    public function test_it_should_pass_domain_event_to_listener_using_short_alias(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('event_dispatcher', EventDispatcher::class);
+        $builder->addCompilerPass(new EventPublisherPass());
+        $builder->register(SomeListener::class, SomeListener::class)->addTag('star.event_listener');
+        $builder->register(MyController::class, MyController::class)
+            ->addArgument(new Reference('star.event_publisher'))
+            ->setPublic(true);
+        $builder->compile();
+
+        /**
+         * @var MyController $service
+         */
+        $service = $builder->get(MyController::class);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('My blog works!!');
+        $service->doAction('My blog');
+    }
+}
+
+final class MyController
+{
+    /**
+     * @var EventPublisher
+     */
+    private $publisher;
+
+    public function __construct(EventPublisher $publisher)
+    {
+        $this->publisher = $publisher;
+    }
+
+    public function doAction(string $name): void
+    {
+        $this->publisher->publish(new BlogWasCreated($name));
+    }
+}
+
+final class SomeListener implements EventListener
+{
+    public function onBlogCreate(BlogWasCreated $event): void
+    {
+        throw new \RuntimeException($event->blogName() . ' works!!');
+    }
+
+    public function listensTo(): array
+    {
+        return [
+            BlogWasCreated::class => 'onBlogCreate',
+        ];
+    }
+}

--- a/tests/Ports/Symfony/SymfonyPublisherTest.php
+++ b/tests/Ports/Symfony/SymfonyPublisherTest.php
@@ -5,9 +5,10 @@
  * (c) Yannick Voyer <star.yvoyer@gmail.com> (http://github.com/yvoyer)
  */
 
-namespace Star\Component\DomainEvent\Symfony;
+namespace Star\Component\DomainEvent\Ports\Symfony;
 
 use PHPUnit\Framework\TestCase;
+use Star\Component\DomainEvent\BadMethodCallException;
 use Star\Component\DomainEvent\EventListener;
 use Star\Component\DomainEvent\Fixtures\Blog\Event\BlogWasCreated;
 use Star\Component\DomainEvent\Fixtures\Blog\Event\UserWasRegistered;
@@ -32,12 +33,12 @@ final class SymfonyPublisherTest extends TestCase implements EventListener
         $this->publisher = new SymfonyPublisher(new EventDispatcher());
     }
 
-    /**
-     * @expectedException        \Star\Component\DomainEvent\BadMethodCallException
-     * @expectedExceptionMessage The method 'onBadMethodCall' do not exists on listener 'Star\Component\DomainEvent\Symfony\MissingMethodListener'.
-     */
     public function test_it_should_throw_exception_when_method_of_listener_do_not_exists(): void
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage(
+            "The method 'onBadMethodCall' do not exists on listener '" . MissingMethodListener::class
+        );
         $this->publisher->subscribe(new MissingMethodListener());
     }
 
@@ -57,17 +58,6 @@ final class SymfonyPublisherTest extends TestCase implements EventListener
         $this->triggered = true;
     }
 
-    /**
-     * Key value map, where key is the event full class name and the map is the method
-     * to call when the event is triggered.
-     *
-     * ie.
-     * array(
-     *     "Full\Path\To\Event" => 'onEvent',
-     * )
-     *
-     * @return array
-     */
     public function listensTo(): array
     {
         return [
@@ -78,17 +68,6 @@ final class SymfonyPublisherTest extends TestCase implements EventListener
 
 final class MissingMethodListener implements EventListener
 {
-    /**
-     * Key value map, where key is the event full class name and the map is the method
-     * to call when the event is triggered.
-     *
-     * ie.
-     * array(
-     *     "Full\Path\To\Event" => 'onEvent',
-     * )
-     *
-     * @return array
-     */
     public function listensTo(): array
     {
         return [


### PR DESCRIPTION
* Add compiler pass that registers an event publisher
* Add documentation about the symfony port
* Update release note for bc break