### PR TITLE
Fix #29 - Add support for ordering on pushed_on column

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ protected function onStuffWasDone(StuffWasDone $event): void;
 
 Note: The callback method can be changed to another format, by overriding the `AggregateRoot::getEventMethod()`.
 
-# Message bus
+## Message bus
 
 The package adds the ability to dispatch messages (`Command` and `Query`). Compared to the `EventPubliser`, the
  `CommandBus` and `QueryBus` have different usages.
@@ -132,11 +132,11 @@ The package adds the ability to dispatch messages (`Command` and `Query`). Compa
 
 ([Example of usage](/examples/Blog/Application/Http/Controller/PostController.php))
  
-# Example
+## Example
 
 The [blog](/examples/blog.phpt) example shows a use case for a blog application.
 
-# Symfony usage
+## Symfony usage
 
 Using a Symfony application, you may use the provided compiler passes to use the buses.
 
@@ -176,3 +176,9 @@ services:
         - { name star.query_handler, message: Path\For\My\Project\FetchStuff }
 ```
 *Note*: In both cases, omitting the message attributes would result in the same behavior.
+
+## Event store
+
+Event stores are where your events will be persisted. You define which platform is used by extending the provided store.
+
+[Example](/docs/ports.md#doctrine-dbal) with `DBALEventStore`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release notes
 
+# 2.4.1
+
+* [#29](https://github.com/yvoyer/domain-event/pull/29) Add support for ordering on pushed_on column
+
 # 2.4.0
 
 * [#28](https://github.com/yvoyer/domain-event/pull/28) Add Payload object to event reconstruction

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -5,3 +5,43 @@ This package currently support the following third party libs or framework:
 * [Symfony framework](/src/Ports/Symfony/README.md)
 
 Note: Any new implementation is welcome. Go submit a PR. 
+
+## Doctrine DBAL
+
+```php
+use Star\Component\DomainEvent\Ports\Doctrine\DBALEventStore;
+
+final MyEventStore extends DBALEventStore 
+{
+    protected function tableName(): string
+    {
+        return '_my_events';
+    }
+
+    protected function createAggregateFromStream(array $events): AggregateRoot
+    {
+        return MyAggregateImplementation::fromStream($events);
+    }
+
+    protected function handleNoEventFound(string $id): void
+    {
+        throw new RuntimeException(\sprintf('My aggregate "%s" not found.', $id));
+    }
+
+    public function loadAggregate(string $id): MyAggregateImplementation
+    {
+        return $this->getAggregateWithId($id);
+    }
+
+    public function saveAggregate(MyAggregateImplementation $aggregate): void
+    {
+        $this->persistAggregate($post->getId(), $aggregate);
+    }
+    
+    protected function getOrderColumns(): array
+    {
+        // Optionally you may override this method to change the column to use for ordering events. (Default = "version")
+        return ['pushed_on'];
+    }
+}
+```

--- a/examples/Blog/Domain/Event/Post/PostTitleWasChanged.php
+++ b/examples/Blog/Domain/Event/Post/PostTitleWasChanged.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Star\Example\Blog\Domain\Event\Post;
+
+use Star\Component\DomainEvent\DomainEvent;
+use Star\Component\DomainEvent\Serialization\CreatedFromTypedPayload;
+use Star\Component\DomainEvent\Serialization\Payload;
+use Star\Example\Blog\Domain\Model\Post\PostId;
+use Star\Example\Blog\Domain\Model\Post\PostTitle;
+
+final class PostTitleWasChanged implements CreatedFromTypedPayload
+{
+    /**
+     * @var PostId
+     */
+    private $postId;
+
+    /**
+     * @var PostTitle
+     */
+    private $oldTitle;
+
+    /**
+     * @var PostTitle
+     */
+    private $newTitle;
+
+    public function __construct(
+        PostId $postId,
+        PostTitle $oldTitle,
+        PostTitle $newTitle
+    ) {
+        $this->postId = $postId;
+        $this->oldTitle = $oldTitle;
+        $this->newTitle = $newTitle;
+    }
+
+    final public function postId(): PostId
+    {
+        return $this->postId;
+    }
+
+    final public function oldTitle(): PostTitle
+    {
+        return $this->oldTitle;
+    }
+
+    final public function newTitle(): PostTitle
+    {
+        return $this->newTitle;
+    }
+
+    public static function fromPayload(Payload $payload): DomainEvent
+    {
+        return new self(
+            PostId::fromString($payload->getString('postId')),
+            new PostTitle($payload->getString('oldTitle')),
+            new PostTitle($payload->getString('newTitle'))
+        );
+    }
+}

--- a/examples/Blog/Domain/Model/BlogId.php
+++ b/examples/Blog/Domain/Model/BlogId.php
@@ -25,4 +25,9 @@ final class BlogId implements SerializableAttribute
     {
         return $this->toString();
     }
+
+    public static function asUuid(): self
+    {
+        return new self(\uniqid('blog-uuid-'));
+    }
 }

--- a/examples/Blog/Domain/Model/Post/PostAggregate.php
+++ b/examples/Blog/Domain/Model/Post/PostAggregate.php
@@ -2,7 +2,9 @@
 
 namespace Star\Example\Blog\Domain\Model\Post;
 
+use DateTimeInterface;
 use Star\Component\DomainEvent\AggregateRoot;
+use Star\Example\Blog\Domain\Event\Post\PostTitleWasChanged;
 use Star\Example\Blog\Domain\Event\Post\PostWasDrafted;
 use Star\Example\Blog\Domain\Event\Post\PostWasPublished;
 use Star\Example\Blog\Domain\Model\BlogId;
@@ -29,9 +31,25 @@ final class PostAggregate extends AggregateRoot
         return $this->id;
     }
 
+    final public function getTitle(): PostTitle
+    {
+        return $this->title;
+    }
+
     public function publish(\DateTimeInterface $publishedAt, string $publishedBy): void
     {
         $this->mutate(new PostWasPublished($this->id, $publishedAt, $publishedBy));
+    }
+
+    public function changeTitle(string $title, DateTimeInterface $date): void
+    {
+        $this->mutate(
+            new PostTitleWasChanged(
+                $this->id,
+                $this->title,
+                new PostTitle($title)
+            )
+        );
     }
 
     public static function draftPost(PostId $id, PostTitle $title, BlogId $blogId): self
@@ -48,5 +66,10 @@ final class PostAggregate extends AggregateRoot
 
     protected function onPostWasPublished(PostWasPublished $event): void
     {
+    }
+
+    protected function onPostTitleWasChanged(PostTitleWasChanged $event): void
+    {
+        $this->title = $event->newTitle();
     }
 }


### PR DESCRIPTION
* Allow to configure the event store to order on different columns.